### PR TITLE
terraform_cloud_implementation_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
 ### 技術選定／クラウドインフラ／クラウド基盤共通
 + IaC）  Terraform Cloud
   
-+ 管理コンソールから作成・有効化したサービス・機能）  IAM, 
++ 管理コンソールから作成・有効化したサービス・機能）  IAM(管理ユーザ作成), 
   
-+ IaCで作成したサービス・機能）  
++ IaCで作成したサービス・機能）  VPC(IPv4), 
   
 + 初期設定で有効化されているサービス・機能）  
   
@@ -49,7 +49,7 @@
 
 <!-- 
 + 管理コンソールから作成・有効化したサービス・機能）  IAM, AWS billing Alarms, AWS Budget, AWS Cost Explorer, 
-+ IaCで作成したサービス・機能）  ECS on Fargate, RDS, ECR, ACM, ALB, VPC（IPv4）, S3, CloudFront, WAF, CloudWatch log, Route53, VPC Flow Logs, AWS Config, KMS, Athena, Amazon Inspector, Guard Duty, 
++ IaCで作成したサービス・機能）  ECS on Fargate, RDS, ECR, ACM, ALB, S3, CloudFront, WAF, CloudWatch log, Route53, VPC Flow Logs, AWS Config, KMS, Athena, Amazon Inspector, Guard Duty, 
 + 初期設定で有効化されているサービス・機能）  CloudTrail, AWS Shield Standard, AWS Health Dashboard, (コスト系も入れる), 
 -->
   

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -1,9 +1,54 @@
+# This tf file consists of VPC, Subnets, Route tables and Internet gateway.
 # -----------------------------------
 # VPC
 # -----------------------------------
 resource "aws_vpc" "vpc" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "172.16.0.0/12"
   tags = {
     Name = format("%s_vpc", var.env_name)
   }
 }
+# -----------------------------------
+# subnets
+# -----------------------------------
+# public subnets
+resource "aws_subnet" "public_subnet" {
+  for_each = {
+    "172.16.1.0/24"  = "ap-northeast-1a"
+    "172.16.17.0/24" = "ap-northeast-1c"
+    "172.16.33.0/24" = "ap-northeast-1d"
+  }
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = each.key
+  availability_zone = each.value
+  tags = {
+    Name = format("%s_public_subnet_%s", var.env_name, each.value)
+  }
+}
+# private subnets
+resource "aws_subnet" "private_subnet" {
+  for_each = {
+    "172.17.1.0/24"  = "ap-northeast-1a"
+    "172.17.2.0/24"  = "ap-northeast-1a"
+    "172.17.17.0/24" = "ap-northeast-1c"
+    "172.17.18.0/24" = "ap-northeast-1c"
+    "172.17.33.0/24" = "ap-northeast-1d"
+    "172.17.34.0/24" = "ap-northeast-1d"
+  }
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = each.key
+  availability_zone = each.value
+  tags = {
+    Name = format("%s_private_subnet_%s", var.env_name, each.value)
+  }
+}
+# -----------------------------------
+# Route tables
+# -----------------------------------
+# a route 
+
+
+
+# -----------------------------------
+# Internet gateway
+# -----------------------------------

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -50,10 +50,29 @@ resource "aws_subnet" "private_subnet" {
 # -----------------------------------
 # Route tables
 # -----------------------------------
-# a route 
+# a route table
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.vpc.id
 
-
-
+  tags = {
+    Name = format("%s_public_rt", var.env_name)
+  }
+}
+resource "aws_route_table_association" "public_rta" {
+  route_table_id = aws_route_table.public_rt.id
+  subnet_id      = aws_subnet.public_subnet[each.value].id
+}
 # -----------------------------------
 # Internet gateway
 # -----------------------------------
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = format("%s_igw", var.env_name)
+  }
+}
+resource "aws_route" "public_rt_igw_r" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+  route_table_id         = aws_route_table.public_rt.id
+}

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -53,14 +53,18 @@ resource "aws_subnet" "private_subnet" {
 # a route table
 resource "aws_route_table" "public_rt" {
   vpc_id = aws_vpc.vpc.id
-
   tags = {
     Name = format("%s_public_rt", var.env_name)
   }
 }
 resource "aws_route_table_association" "public_rta" {
   route_table_id = aws_route_table.public_rt.id
-  subnet_id      = aws_subnet.public_subnet[each.value].id
+  for_each = {
+    "172.30.1.0/24"  = "ap-northeast-1a"
+    "172.30.17.0/24" = "ap-northeast-1c"
+    "172.30.33.0/24" = "ap-northeast-1d"
+  }
+  subnet_id = aws_subnet.public_subnet[each.key].id
 }
 # -----------------------------------
 # Internet gateway

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -80,7 +80,7 @@ resource "aws_route_table_association" "public_rta" {
   }
   subnet_id = aws_subnet.public_subnet[each.key].id
 }
-# a route table on private subnets without a route just to disuse default route table 
+# a route table on private subnets just to disuse default route table 
 resource "aws_route_table" "private_rt" {
   vpc_id = aws_vpc.vpc.id
   tags = {
@@ -98,9 +98,4 @@ resource "aws_route_table_association" "private_rta" {
     "172.30.35.0/24" = "ap-northeast-1d"
   }
   subnet_id = aws_subnet.private_subnet[each.key].id
-}
-# create a new default route table on VPC just to disuse a default route table 
-resource "aws_main_route_table_association" "main_rt_table" {
-  vpc_id         = aws_vpc.vpc.id
-  route_table_id = aws_route_table.public_rt.id
 }

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -50,7 +50,7 @@ resource "aws_subnet" "private_subnet" {
 # -----------------------------------
 # Route tables
 # -----------------------------------
-# a route table
+# a public route table
 resource "aws_route_table" "public_rt" {
   vpc_id = aws_vpc.vpc.id
   tags = {

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -3,7 +3,7 @@
 # VPC
 # -----------------------------------
 resource "aws_vpc" "vpc" {
-  cidr_block = "172.16.0.0/12"
+  cidr_block = "172.30.0.0/16"
   tags = {
     Name = format("%s_vpc", var.env_name)
   }
@@ -14,9 +14,9 @@ resource "aws_vpc" "vpc" {
 # public subnets
 resource "aws_subnet" "public_subnet" {
   for_each = {
-    "172.16.1.0/24"  = "ap-northeast-1a"
-    "172.16.17.0/24" = "ap-northeast-1c"
-    "172.16.33.0/24" = "ap-northeast-1d"
+    "172.30.1.0/24"  = "ap-northeast-1a"
+    "172.30.17.0/24" = "ap-northeast-1c"
+    "172.30.33.0/24" = "ap-northeast-1d"
   }
   vpc_id            = aws_vpc.vpc.id
   cidr_block        = each.key
@@ -28,12 +28,12 @@ resource "aws_subnet" "public_subnet" {
 # private subnets
 resource "aws_subnet" "private_subnet" {
   for_each = {
-    "172.17.1.0/24"  = "ap-northeast-1a"
-    "172.17.2.0/24"  = "ap-northeast-1a"
-    "172.17.17.0/24" = "ap-northeast-1c"
-    "172.17.18.0/24" = "ap-northeast-1c"
-    "172.17.33.0/24" = "ap-northeast-1d"
-    "172.17.34.0/24" = "ap-northeast-1d"
+    "172.30.2.0/24"  = "ap-northeast-1a"
+    "172.30.3.0/24"  = "ap-northeast-1a"
+    "172.30.18.0/24" = "ap-northeast-1c"
+    "172.30.19.0/24" = "ap-northeast-1c"
+    "172.30.34.0/24" = "ap-northeast-1d"
+    "172.30.35.0/24" = "ap-northeast-1d"
   }
   vpc_id            = aws_vpc.vpc.id
   cidr_block        = each.key

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -99,3 +99,8 @@ resource "aws_route_table_association" "private_rta" {
   }
   subnet_id = aws_subnet.private_subnet[each.key].id
 }
+# create a new default route table on VPC just to disuse a default route table 
+resource "aws_main_route_table_association" "main_rt_table" {
+  vpc_id         = aws_vpc.vpc.id
+  route_table_id = aws_route_table.public_rt.id
+}

--- a/terraform/envs/main_region/network.tf
+++ b/terraform/envs/main_region/network.tf
@@ -3,7 +3,10 @@
 # VPC
 # -----------------------------------
 resource "aws_vpc" "vpc" {
-  cidr_block = "172.30.0.0/16"
+  cidr_block                       = "172.30.0.0/16"
+  enable_dns_hostnames             = true # VPC内のインスタンスがDNSホスト名を取得する。またAWSサービス間での通信を可能にする場合がある。
+  enable_dns_support               = true # デフォルトでtrueだが指定。VPC内でのサービス間の通信に必須。
+  assign_generated_ipv6_cidr_block = false
   tags = {
     Name = format("%s_vpc", var.env_name)
   }
@@ -18,11 +21,12 @@ resource "aws_subnet" "public_subnet" {
     "172.30.17.0/24" = "ap-northeast-1c"
     "172.30.33.0/24" = "ap-northeast-1d"
   }
-  vpc_id            = aws_vpc.vpc.id
-  cidr_block        = each.key
-  availability_zone = each.value
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = each.key
+  availability_zone       = each.value
+  map_public_ip_on_launch = true
   tags = {
-    Name = format("%s_public_subnet_%s", var.env_name, each.value)
+    Name = format("%s_public_%s", var.env_name, each.value)
   }
 }
 # private subnets
@@ -35,11 +39,12 @@ resource "aws_subnet" "private_subnet" {
     "172.30.34.0/24" = "ap-northeast-1d"
     "172.30.35.0/24" = "ap-northeast-1d"
   }
-  vpc_id            = aws_vpc.vpc.id
-  cidr_block        = each.key
-  availability_zone = each.value
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = each.key
+  availability_zone       = each.value
+  map_public_ip_on_launch = false
   tags = {
-    Name = format("%s_private_subnet_%s", var.env_name, each.value)
+    Name = format("%s_private_%s", var.env_name, each.value)
   }
 }
 # -----------------------------------

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -1,0 +1,89 @@
+# -----------------------------------
+# Security groups and Security group rules
+# Terraform official no longer recommends using "aws_security_group_rule" and insted suggests "aws_vpc_security_group_ingress_rule" and "aws_vpc_security_group_egress_rule".
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
+# -----------------------------------
+# web sg
+resource "aws_security_group" "web_sg" {
+  name        = format("%s_sg_web", var.env_name)
+  vpc_id      = aws_vpc.vpc.id
+  description = "sg"
+  tags = {
+    Name = format("%s_web_sg", var.env_name)
+  }
+}
+# web sgr
+# TODO CloudFrontを実装した際に、ALBは"0.0.0.0/0"からではなく、CloudFrontからのみアクセスを許可できるかを検討する。
+resource "aws_vpc_security_group_ingress_rule" "web_sg_in_http" { # 80版ポートはALBでのリダイレクト用に空けておく。
+  security_group_id = aws_security_group.web_sg.id
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+resource "aws_vpc_security_group_ingress_rule" "web_sg_in_https" {
+  security_group_id = aws_security_group.web_sg.id
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+resource "aws_vpc_security_group_egress_rule" "web_sg_out_all" { # 今後の拡張性を考え明示的に設定。
+  security_group_id = aws_security_group.web_sg.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+# fargate sg
+resource "aws_security_group" "fargate_sg" {
+  name        = format("%s_sg_fargate", var.env_name)
+  vpc_id      = aws_vpc.vpc.id
+  description = "sg"
+  tags = {
+    Name = format("%s_fargate_sg", var.env_name)
+  }
+}
+# fargate sgr
+resource "aws_vpc_security_group_ingress_rule" "fargate_sg_in_http" {
+  security_group_id            = aws_security_group.web_sg.id
+  from_port                    = 80
+  to_port                      = 80
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws.security_group_id.web_sg.id
+}
+# TODO Systems Managerからのingressを後々必要になった時に追記する。
+# TODO ECS on Fargateの実装時の原因切り分けを容易にするため、下記で一旦Fargateのプライベートサブネットのegress通信を全て許可する。実装完了後、想定されている通信のみegress許可する。現在想定：DBとS3への通信。
+resource "aws_vpc_security_group_egress_rule" "fargate_sg_out_all" {
+  security_group_id = aws_security_group.web_sg.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+# db sg
+resource "aws_security_group" "db_sg" {
+  name        = format("%s_sg_fargate", var.env_name)
+  vpc_id      = aws_vpc.vpc.id
+  description = "sg"
+  tags = {
+    Name = format("%s_db_sg", var.env_name)
+  }
+}
+# db sgr
+resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {
+  security_group_id            = aws_security_group.db_sg.id
+  from_port                    = 3306
+  to_port                      = 3306
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.fargate_sg.id
+}
+# db sgrでは、fargateへの通信を許可するegressルールは追加しない。
+# 理由 デフォルトでegreeルールは全て許可だが、何かしらのセキュリティグループを作成した段階でegressルールは仕様で全て拒否になる。この拒否ルールはDBサブネットで想定された設定。また、ingressでfargateからの通信は許可しているため、ステートフルの観点からfargateへの応答通信は成立し、問題がないため。
+resource "aws_vpc_security_group_egress_rule" "db_sg_out_fargate" { # fargateへの通信のみ許可。
+  security_group_id            = aws_security_group.db_sg.id
+  from_port                    = 0
+  to_port                      = 0
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.fargate_sg.id
+}

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -32,7 +32,7 @@ resource "aws_vpc_security_group_egress_rule" "web_sg_out_all" { # 今後の拡�
   security_group_id = aws_security_group.web_sg.id
   from_port         = 0
   to_port           = 0
-  ip_protocol       = "-1"
+  ip_protocol       = "tcp" # 仕様上、ここを"-1"にするとエラーになる。(ポートとプロトコルを同時に全て開放できない模様。)
   cidr_ipv4         = "0.0.0.0/0"
 }
 # fargate sg
@@ -58,12 +58,12 @@ resource "aws_vpc_security_group_egress_rule" "fargate_sg_out_all" {
   security_group_id = aws_security_group.fargate_sg.id
   from_port         = 0
   to_port           = 0
-  ip_protocol       = "-1"
+  ip_protocol       = "tcp" # 仕様上、ここを"-1"にするとエラーになる。(ポートとプロトコルを同時に全て開放できない模様。)
   cidr_ipv4         = "0.0.0.0/0"
 }
 # db sg
 resource "aws_security_group" "db_sg" {
-  name        = format("%s_sg_fargate", var.env_name)
+  name        = format("%s_sg_db", var.env_name)
   vpc_id      = aws_vpc.vpc.id
   description = "sg"
   tags = {
@@ -80,10 +80,3 @@ resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {
 }
 # db sgrでは、fargateへの通信を許可するegressルールは追加しない。
 # 理由 デフォルトでegreeルールは全て許可だが、何かしらのセキュリティグループを作成した段階でegressルールは仕様で全て拒否になる。この拒否ルールはDBサブネットで想定された設定。また、ingressでfargateからの通信は許可しているため、ステートフルの観点からfargateへの応答通信は成立し、問題がないため。
-resource "aws_vpc_security_group_egress_rule" "db_sg_out_fargate" { # fargateへの通信のみ許可。
-  security_group_id            = aws_security_group.db_sg.id
-  from_port                    = 0
-  to_port                      = 0
-  ip_protocol                  = "tcp"
-  referenced_security_group_id = aws_security_group.fargate_sg.id
-}

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -50,7 +50,7 @@ resource "aws_vpc_security_group_ingress_rule" "fargate_sg_in_http" {
   from_port                    = 80
   to_port                      = 80
   ip_protocol                  = "tcp"
-  referenced_security_group_id = aws.security_group_id.web_sg.id
+  referenced_security_group_id = aws_security_group.web_sg.id
 }
 # TODO Systems Managerからのingressを後々必要になった時に追記する。
 # TODO ECS on Fargateの実装時の原因切り分けを容易にするため、下記で一旦Fargateのプライベートサブネットのegress通信を全て許可する。実装完了後、想定されている通信のみegress許可する。現在想定：DBとS3への通信。

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -37,7 +37,7 @@ resource "aws_vpc_security_group_egress_rule" "web_sg_out_all" { # 今後の拡�
 }
 # fargate sg
 resource "aws_security_group" "fargate_sg" {
-  name        = format("%s_sg_fargate", var.env_name)
+  name        = format("%s_sg_fargate_v2_test", var.env_name)
   vpc_id      = aws_vpc.vpc.id
   description = "sg"
   tags = {

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -46,7 +46,7 @@ resource "aws_security_group" "fargate_sg" {
 }
 # fargate sgr
 resource "aws_vpc_security_group_ingress_rule" "fargate_sg_in_http" {
-  security_group_id            = aws_security_group.web_sg.id
+  security_group_id            = aws_security_group.fargate_sg.id
   from_port                    = 80
   to_port                      = 80
   ip_protocol                  = "tcp"
@@ -55,7 +55,7 @@ resource "aws_vpc_security_group_ingress_rule" "fargate_sg_in_http" {
 # TODO Systems Managerからのingressを後々必要になった時に追記する。
 # TODO ECS on Fargateの実装時の原因切り分けを容易にするため、下記で一旦Fargateのプライベートサブネットのegress通信を全て許可する。実装完了後、想定されている通信のみegress許可する。現在想定：DBとS3への通信。
 resource "aws_vpc_security_group_egress_rule" "fargate_sg_out_all" {
-  security_group_id = aws_security_group.web_sg.id
+  security_group_id = aws_security_group.fargate_sg.id
   from_port         = 0
   to_port           = 0
   ip_protocol       = "-1"

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -37,7 +37,7 @@ resource "aws_vpc_security_group_egress_rule" "web_sg_out_all" { # 今後の拡�
 }
 # fargate sg
 resource "aws_security_group" "fargate_sg" {
-  name        = format("%s_sg_fargate_v2_test", var.env_name)
+  name        = format("%s_sg_fargate", var.env_name)
   vpc_id      = aws_vpc.vpc.id
   description = "sg"
   tags = {


### PR DESCRIPTION
下記の実装を行う

- VPC
- サブネット
- ルートテーブル
- インターネットゲートウェイ
- セキュリティグループ

# ネットワーク設計

- 拡張性のあるアドレス設計

VPC：172.30.0.0/16
RFC1918で定義されたプライベートIPアドレスのCIDRのうち、クラスB(172.16.0.0/12)のCIDRを使用。これにより、クラスA(10.0.0.0/8)、クラスC(192.168.0.0/16)のアドレス空間を持つシステムとの統合を容易になるように設計。
プライベートサブネットは、将来AZが増える事とAZ内のサブネットが増える事を考慮したCIDR設計。
172.30.0.0/20、172.30.16.0/20、172.30.32.0/20をAZのCIDRとして暗示的に設定。

172.30.0.0/16　VPC
172.30.0.0/20　1a(暗示的に定義)
172.30.1.0/24　pub-subnet
172.30.2.0/24　prv-subnet
172.30.3.0/24　prv-subnet

172.30.16.0/20　1c(暗示的に定義)
172.30.17.0/24　pub-subnet
172.30.18.0/24　prv-subnet
172.30.19.0/24　prv-subnet

172.30.32.0/20　1d(暗示的に定義)
172.30.33.0/24　pub-subnet
172.30.34.0/24　prv-subnet
172.30.35.0/24　prv-subnet

# メモ

- 同じセキュリティグループを持つインスタンスからインスタンスに接続するためのルールは”-1”。

> https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/security-group-rules-reference.html#sg-rules-other-instances

- VPC作成時にデフォルトでルートテーブルが作成される。しかし、デフォルトルートテーブルの利用はアンチパターンである場合があるため、必要であれば関連付けを行う。

> 公式 : Resource: aws_main_route_table_association
> https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/main_route_table_association

- Resourceにおける、`aws_route`、`aws_route_table`、`aws_route_table_association`、`aws_main_route_table_association`、`aws_default_route_table`の違いについて(下記の必須以外の設定値は主に使用が想定されるオプション値。)

    - **aws_route(特定のルートテーブルにルートを追加するためのもの。ルートテーブルに複数のルートを動的に追加することができる。)**
        - route_table_id(必須)
        - destination_cidr_block
        - gateway_id
    - **aws_route_table(新しいルートテーブルを作成するためのもの。)**
        - vpc_id(必須)
        - cidr_block(必須)
    - **aws_route_table_association(特定のサブネットとルートテーブルを関連付けるためのもの。)**
        - route_table_id(必須)
        - subnet_id　もしくは、gateway_id　のどちらか(必須)
    - **aws_main_route_table_association(下記のaws_default_route_tableと同時に設定は不可。特定のVPC の メインルートテーブル を変更するためのリソース。)**
        - vpc_id(必須)
        - route_table_id(必須)
    - **aws_default_route_table(上記のaws_main_route_table_associationと同時に設定は不可。VPC が作成されるときに自動的に作成される デフォルトのルートテーブル を管理するためのリソース。)**
        - default_route_table_id(必須)
        - cidr_block(必須)

> 参考
> https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table
> 
>> Every VPC has a default route table that can be managed but not destroyed. When Terraform first adopts a default route table, it immediately removes all defined routes. It then proceeds to create any routes specified in the configuration. This step is required so that only the routes specified in the configuration exist in the default route table.

- デフォルトではVPC内のサブネット間の通信ができる仕様なので、例えばALBが配置されているパブリックサブネットからDBの配置されているプライベートサブネットへはルーティンがされていると想定。このルーティングを廃止して、パブリックサブネット(ALB)→プライベートサブネット1(Fargate)→プライベートサブネット2(DB)とルーティングする方法は、下記の理由により採用しない。
    - ベストプラクティスに無い
    - 様々なWEBサイトで採用されていない
    - 仮に可能だとしても複雑で、ミスを誘発する可能性がある
    - セキュリティグループを設定する事により、セキュリティ上問題ないと判断できる

- デフォルトのセキュリティグループはegressを全て許可するルール。しかし、一度セキュリティグループを作成するとこの許可ルールが無くなる。

> https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group

> 