### PR TITLE
Implementation_fargate_ECSExec

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
   
 ## 技術選定／開発ツール
 + Docker Desktop 4.25.0
-+ aws-cli 2.13.27(オートコンプリート)
++ aws-cli 2.13.27(オートコンプリート, Session Manager plugin for the AWS CLI)
 + Terraform v1.6.2(CLI環境)
 + pyenv 2.3.27
   

--- a/terraform/envs/main_region/cloudwatch_logs.tf
+++ b/terraform/envs/main_region/cloudwatch_logs.tf
@@ -17,3 +17,7 @@ resource "aws_cloudwatch_log_group" "ecs" {
   name              = format("/aws/ecs/%s", var.env_name)
   retention_in_days = 90
 }
+resource "aws_cloudwatch_log_group" "ecs_exec" {
+  name              = format("/aws/ecs_exec/%s", var.env_name)
+  retention_in_days = 90
+}

--- a/terraform/envs/main_region/ecs.tf
+++ b/terraform/envs/main_region/ecs.tf
@@ -15,8 +15,8 @@ resource "aws_ecs_cluster" "cluster" {
       log_configuration {
         cloud_watch_encryption_enabled = true
         cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs_exec.name
-*/
       }
+*/
     }
   }
 }

--- a/terraform/envs/main_region/ecs.tf
+++ b/terraform/envs/main_region/ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_cluster" "cluster" {
   }
   configuration {
     execute_command_configuration {
-      logging = "OVERRIDE"
+      logging = "NONE"
       log_configuration {
         cloud_watch_encryption_enabled = true
         cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs_exec.name

--- a/terraform/envs/main_region/ecs.tf
+++ b/terraform/envs/main_region/ecs.tf
@@ -11,9 +11,11 @@ resource "aws_ecs_cluster" "cluster" {
   configuration {
     execute_command_configuration {
       logging = "NONE"
+/*
       log_configuration {
         cloud_watch_encryption_enabled = true
         cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs_exec.name
+*/
       }
     }
   }

--- a/terraform/envs/main_region/ecs.tf
+++ b/terraform/envs/main_region/ecs.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_cluster" "cluster" {
       logging = "OVERRIDE"
       log_configuration {
         cloud_watch_encryption_enabled = true
-        cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs.name
+        cloud_watch_log_group_name     = aws_cloudwatch_log_group.ecs_exec.name
       }
     }
   }

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -32,7 +32,7 @@ resource "aws_vpc_security_group_egress_rule" "web_sg_out_all" { # 今後の拡�
   security_group_id = aws_security_group.web_sg.id
   from_port         = 0
   to_port           = 0
-  ip_protocol       = "tcp" # 仕様上、ここを"-1"にするとエラーになる。(ポートとプロトコルを同時に全て開放できない模様。)
+  ip_protocol       = "-1" # ここを「TCPで他を全て開放設定」にすると、ターゲットグループは起動中のコンテナを登録できない。コンテナが200を返さない。
   cidr_ipv4         = "0.0.0.0/0"
 }
 # fargate sg
@@ -76,11 +76,11 @@ resource "aws_security_group" "db_sg" {
 # db sgr
 # 障害切り分け用に、下記の全許可設定を実装
 resource "aws_vpc_security_group_ingress_rule" "db_sg_in_all" {
-  security_group_id            = aws_security_group.db_sg.id
-  from_port                    = 0
-  to_port                      = 0
-  ip_protocol                  = "-1"
-  cidr_ipv4                    = "0.0.0.0/0"
+  security_group_id = aws_security_group.db_sg.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
 }
 /*
 resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -74,6 +74,15 @@ resource "aws_security_group" "db_sg" {
   }
 }
 # db sgr
+# 障害切り分け用に、下記の全許可設定を実装
+resource "aws_vpc_security_group_ingress_rule" "db_sg_in_all" {
+  security_group_id            = aws_security_group.db_sg.id
+  from_port                    = 0
+  to_port                      = 0
+  ip_protocol                  = "-1"
+  cidr_ipv4                    = "0.0.0.0/0"
+}
+/*
 resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {
   security_group_id            = aws_security_group.db_sg.id
   from_port                    = 3306
@@ -81,6 +90,7 @@ resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {
   ip_protocol                  = "tcp"
   referenced_security_group_id = aws_security_group.fargate_sg.id
 }
+*/
 resource "aws_vpc_security_group_egress_rule" "db_sg_out_all" {
   security_group_id = aws_security_group.db_sg.id
   from_port         = 0

--- a/terraform/envs/main_region/security_group.tf
+++ b/terraform/envs/main_region/security_group.tf
@@ -81,8 +81,14 @@ resource "aws_vpc_security_group_ingress_rule" "db_sg_in_tcp3306" {
   ip_protocol                  = "tcp"
   referenced_security_group_id = aws_security_group.fargate_sg.id
 }
-# db sgrでは、fargateへの通信を許可するegressルールは追加しない。
-# 理由 デフォルトでegreeルールは全て許可だが、何かしらのセキュリティグループを作成した段階でegressルールは仕様で全て拒否になる。この拒否ルールはDBサブネットで想定された設定。また、ingressでfargateからの通信は許可しているため、ステートフルの観点からfargateへの応答通信は成立し、問題がないため。
+resource "aws_vpc_security_group_egress_rule" "db_sg_out_all" {
+  security_group_id = aws_security_group.db_sg.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+# デフォルトでegreeルールは全て許可だが、何かしらのセキュリティグループを作成した段階でegressルールは仕様で全て拒否になる。この拒否ルールはDBサブネットで想定された設定。また、ingressでfargateからの通信は許可しているため、ステートフルの観点からfargateへの応答通信は成立し、問題がないため。
 # vpc endpoint sg
 /*
 resource "aws_security_group" "vpc_endpoint_sg" {


### PR DESCRIPTION
# このブランチで行うこと
FargateコンテナへのExec接続機能を実装する

# 実装内容

- SSM(ECSExec用)
   - ローカルのCLIに、Session Manager plugin for the AWS CLIがインストールされている点を確認
   - ECS ExecがECSサービスで有効化設定になっている点を確認するために、ローカルのCLIで下記コマンドを実行
      - `session-manager-plugin`
   - IAM ロール にSSMエージェントの実行用のポリシーをアタッチ
      - その他の権限設定は下記を実装(TODO未実装)
      - https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-logging
   - CloudWatch Logsへのログ書き込みは未実装

# 参考
- Amazon CloudWatch Logs を使用したセッションデータのログ記録 (コンソール）
   - https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/session-manager-logging.html#session-manager-logging-cloudwatch-logs

# メモ

- ローカルのCLIからECS Execが有効かどうかを確認するコマンド
   - `aws ecs describe-services --cluster prod_ecs_cluster --services prod_ecs_service | grep enableExecuteCommand
`
- ローカルCLIからECS Execを実行するコマンド
   - `aws ecs execute-command --cluster クラスター名 --task タスクARN --container コンテナ名 --interactive --command "/bin/sh" \`
